### PR TITLE
摌 → 剷

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Notepad++ 轉介面語言嘅講法係叫 localization 而唔係 translation，�
 - 呢個 repo 名應該叫「香港廣東話」丶「香港粵語」定係叫「香港語」，注意要能夠配合番譯做英文要睇得明，仲有跟 Notepad++ 選擇語言嘅一致性。 **（希望盡早決定）**
 - Typo丶錯別字丶文法。
 - 整體嚟講啲字詞丶語法等嘅用字，有冇一致性嘅問題。
-- 實際畫面上有冇 overflow 嘅問題，搞到啲字顯示唔到响個 mon 到，歡迎搵搵 XML comment 咗 `<-- #todo reproduce -->` 嘅 line。冇顯示問題嘅話，大可以開 PR 摌走個 comment；有顯示問題，就開個 issue。
+- 實際畫面上有冇 overflow 嘅問題，搞到啲字顯示唔到响個 mon 到，歡迎搵搵 XML comment 咗 `<-- #todo reproduce -->` 嘅 line。冇顯示問題嘅話，大可以開 PR 剷走個 comment；有顯示問題，就開個 issue。
 - 用字上，正字丶異體字同埋約定俗成點樣拿捏（例如「d」vs「啲」），仲有 Windows 字型顯示（例如「𠹺」丶「𡁵」），需要大家討論。
 
 

--- a/hongKongCantonese.xml
+++ b/hongKongCantonese.xml
@@ -111,13 +111,13 @@
                     <Item id="42003" name="還原(&amp;U)"/>
                     <Item id="42004" name="重做(&amp;R)"/>
                     <Item id="42005" name="貼(&amp;P)"/>
-                    <Item id="42006" name="摌(&amp;D)"/>
+                    <Item id="42006" name="剷(&amp;D)"/>
                     <Item id="42007" name="揀晒(&amp;A)"/>
                     <Item id="42020" name="開始揀/揀完"/>
                     <Item id="42008" name="增加縮排"/>
                     <Item id="42009" name="減少縮排"/>
                     <Item id="42010" name="重複呢行"/>
-                    <Item id="42077" name="摌走連續又重複呢（幾）行"/>
+                    <Item id="42077" name="剷走連續又重複呢（幾）行"/>
                     <Item id="42012" name="分割呢行"/>
                     <Item id="42013" name="合併呢（幾）行"/>
                     <Item id="42014" name="移呢行上去"/>
@@ -156,7 +156,7 @@
                     <Item id="42042" name="剔走行前啲空格同埋 tab"/>
                     <Item id="42043" name="剔走呢行頭尾啲空格同埋 tab"/>
                     <Item id="42044" name="EOL -> 空格"/>
-                    <Item id="42045" name="摌走冇用嘅空格同埋 EOL"/>
+                    <Item id="42045" name="剷走冇用嘅空格同埋 EOL"/>
                     <Item id="42046" name="Tab -> 空格"/>
                     <Item id="42054" name="空格 -> tab（成份檔案）"/>
                     <Item id="42053" name="空格 -> tab（淨係行首）"/>
@@ -190,8 +190,8 @@
                     <Item id="42033" name="取消唯讀屬性"/>
                     <Item id="42035" name="轉做單行式註解"/>
                     <Item id="42036" name="取消單行式註解"/>
-                    <Item id="42055" name="摌走空行"/>
-                    <Item id="42056" name="摌走空行（只有空白字元嘅都照摌）"/>
+                    <Item id="42055" name="剷走空行"/>
+                    <Item id="42056" name="剷走空行（只有空白字元嘅都照剷）"/>
                     <Item id="42057" name="响上面加一行"/>
                     <Item id="42058" name="响下面加一行"/>
 
@@ -207,8 +207,8 @@
                     <Item id="43018" name="剪低書籤嗰幾行"/>
                     <Item id="43019" name="抄低書籤嗰幾行"/>
                     <Item id="43020" name="貼去兼取代書籤嗰幾行"/>
-                    <Item id="43021" name="摌走書籤嗰幾行"/>
-                    <Item id="43051" name="摌走冇書籤標記嗰幾行"/>
+                    <Item id="43021" name="剷走書籤嗰幾行"/>
+                    <Item id="43051" name="剷走冇書籤標記嗰幾行"/>
                     <Item id="43050" name="反向標記書籤"/>
                     <Item id="43052" name="以字元編號搵字元..."/>
                     <Item id="43053" name="揀選括號之間全部字元"/>
@@ -384,13 +384,13 @@
 
                     <!-- menu: File (cont'd) -->
                     <Item id="42040" name="打開所有最近用過嘅檔案"/>
-                    <Item id="42041" name="摌晒最近用過嘅檔案記錄"/>
+                    <Item id="42041" name="剷晒最近用過嘅檔案記錄"/>
 
                     <!-- menu: Macro (cont'd) -->
-                    <Item id="48016" name="修改快捷鍵或者摌走 Macro..."/>
+                    <Item id="48016" name="修改快捷鍵或者剷走 Macro..."/>
 
                     <!-- menu: Run (cont'd) -->
-                    <Item id="48017" name="修改快捷鍵或者摌走執行指令..."/>
+                    <Item id="48017" name="修改快捷鍵或者剷走執行指令..."/>
 
                 </Commands>
             </Main>
@@ -522,7 +522,7 @@
                 <Item id="5501" name="搵："/>
                 <Item id="5503" name="安裝"/>
                 <Item id="5504" name="更新"/>
-                <Item id="5505" name="摌走"/>
+                <Item id="5505" name="剷走"/>
                 <Item id="5508" name="下一個"/>
                 <Item id="2"    name="閂"/>
             </PluginsAdminDlg>
@@ -560,7 +560,7 @@
 
             <ShortcutMapper title="快捷鍵配對">
                 <Item id="2602" name="修改"/>
-                <Item id="2603" name="摌走"/>
+                <Item id="2603" name="剷走"/>
                 <Item id="2606" name="清除"/>
                 <Item id="2607" name="過濾："/>
                 <Item id="1" name="閂"/>
@@ -582,9 +582,9 @@
                 <Item id="2" name="取消"/>
                 <Item id="5006" name="名"/>
                 <Item id="5008" name="加料"/>
-                <Item id="5009" name="摌走"/>
+                <Item id="5009" name="剷走"/>
                 <Item id="5010" name="套用"/>
-                <Item id="5007" name="咁會摌走快捷鍵"/>
+                <Item id="5007" name="咁會剷走快捷鍵"/>
                 <Item id="5012" name="有衝突啊喂！"/>
             </ShortcutMapperSubDialg>
 
@@ -592,7 +592,7 @@
                 <Item id="20001" name="靠邊"/>
                 <Item id="20002" name="改名"/>
                 <Item id="20003" name="開新..."/>
-                <Item id="20004" name="摌除"/>
+                <Item id="20004" name="剷除"/>
                 <Item id="20005" name="Save 做新..."/>
                 <Item id="20007" name="自訂程式語言："/>
                 <Item id="20009" name="副檔名："/>
@@ -1098,7 +1098,7 @@
             <DocReloadWarning title="响磁碟重新 load 過" message="留意返！改過嘅嘢會冇晒，係咪真係要再 load 過呢個檔案？"/>
             <FileLockedWarning title="儲存失敗" message="麻煩您檢查吓，係咪有其它應用程式開咗呢個檔案。"/>
             <FileAlreadyOpenedInNpp title="" message="已經响 Notepad++ 度開咗呢個檔案。"/> <!-- #todo reproduce -->
-            <DeleteFileFailed title="掉去垃圾桶" message="摌唔走個檔案。"/> <!-- #todo reproduce -->
+            <DeleteFileFailed title="掉去垃圾桶" message="剷唔走個檔案。"/> <!-- #todo reproduce -->
 
             <NbFileToOpenImportantWarning title="太多檔案" message="成 $INT_REPLACE$ 個檔案咁多，
 係咪真係要開晒先？"/> <!-- #todo reproduce -->
@@ -1116,8 +1116,8 @@
 仲使唔使 keep 著呢個檔案呢？"/>
             <DoDeleteOrNot title="掉去垃圾桶" message="咁做會掉去垃圾桶仲會閂咗呢個檔案「
 $STR_REPLACE$
-」，係咪真係要摌先？"/>
-            <NoBackupDoSaveFile title="Save" message="檔案嘅備份已經畀另一個程式摌走咗。
+」，係咪真係要剷先？"/>
+            <NoBackupDoSaveFile title="Save" message="檔案嘅備份已經畀另一個程式剷走咗。
 如果唔想遺失數據就 save 低佢啦。
 您想唔想 save「$STR_REPLACE$」呢？"/>
             <DoReloadOrNot title="Reload" message="「$STR_REPLACE$」
@@ -1146,7 +1146,7 @@ Reload 會放棄您响 Notepad++ 改過嘅嘢，咁仲繼唔繼續呢？"/>
 使唔使回復個檔案？"/> <!-- #todo reproduce -->
             <LoadLangsFailedFinal title="設定" message="Load 唔到「langs.xml」。"/> <!-- #todo reproduce -->
             <FolderAsWorspaceSubfolderExists title="資料夾工作區問題" message="您要加入嘅資料夾「$STR_REPLACE$」，已經以子資料夾嘅形式出現响工作區裏面。
-如果您仍然想咁做，唯有响工作區摌走包含佢嘅資料夾，先至可以加番上去。"/> <!-- #todo reproduce -->
+如果您仍然想咁做，唯有响工作區剷走包含佢嘅資料夾，先至可以加番上去。"/> <!-- #todo reproduce -->
 
             <ProjectPanelChanged title="$STR_REPLACE$" message="Project 工作區有嘢改動過，使唔使 save？"/>
             <ProjectPanelChangedSaveError title="$STR_REPLACE$" message="Project 工作區冇 save 到。"/> <!-- #todo reproduce -->
@@ -1154,16 +1154,16 @@ Reload 會放棄您响 Notepad++ 改過嘅嘢，咁仲繼唔繼續呢？"/>
             <ProjectPanelNewDoSaveDirtyWsOrNot title="新工作區" message="您用緊呢個工作區改過嘢，使唔使 save 咗佢先呢？"/>
             <ProjectPanelOpenFailed title="打開工作區" message="打唔開個工作區。
 似乎係個工作區檔案無效又或者損毀咗。"/>
-            <ProjectPanelRemoveFolderFromProject title="响 project 度摌走資料夾" message="咁樣會摌走埋佢啲子項目。
-係咪真係要响 project 度摌走呢個資料夾？"/>
-            <ProjectPanelRemoveFileFromProject title="响 project 度摌走檔案" message="係咪真係要响 project 度摌走呢個檔案？"/>
+            <ProjectPanelRemoveFolderFromProject title="响 project 度剷走資料夾" message="咁樣會剷走埋佢啲子項目。
+係咪真係要响 project 度剷走呢個資料夾？"/>
+            <ProjectPanelRemoveFileFromProject title="响 project 度剷走檔案" message="係咪真係要响 project 度剷走呢個檔案？"/>
             <ProjectPanelReloadError title="Reload 工作區" message="搵唔到要 reload 嘅檔案。"/>
             <ProjectPanelReloadDirty title="Reload 工作區" message="呢個工作區已經改過嘢。Reload 會捨棄啲改動。
 仲繼唔繼續？"/>
             <UDLNewNameError title="自訂程式語言錯誤" message="呢個名已經畀另一個程式語言用咗。
 唔該改另一個名啦。"/>
-            <UDLRemoveCurrentLang title="摌除程式語言" message="係咪真係要咁做？"/>
-            <SCMapperDoDeleteOrNot title="摌除快捷鍵" message="係咪真係要咁做"/>
+            <UDLRemoveCurrentLang title="剷除程式語言" message="係咪真係要咁做？"/>
+            <SCMapperDoDeleteOrNot title="剷除快捷鍵" message="係咪真係要咁做"/>
             <FindCharRangeValueError title="輸入值範圍錯誤" message="您輸入嘅數值應該要介乎 0 到 255 之間先至啱。"/>
             <OpenInAdminMode title="Save 唔到" message="Save 唔到，可能係因為個檔案响保護狀態。
 想唔想用系統管理員身份重新打開 Notepad++？"/>
@@ -1210,8 +1210,8 @@ Reload 會放棄您响 Notepad++ 改過嘅嘢，咁仲繼唔繼續呢？"/>
             <PanelTitle name="資料夾工作區"/>
             <SelectFolderFromBrowserString name="揀個資料夾嚟加入去資料夾工作區"/>
             <Menus>
-                <Item id="3511" name="摌走"/>
-                <Item id="3512" name="摌走晒佢"/>
+                <Item id="3511" name="剷走"/>
+                <Item id="3512" name="剷走晒佢"/>
                 <Item id="3513" name="加料"/>
                 <Item id="3514" name="响系統預設程式打開"/>
                 <Item id="3515" name="打開"/>
@@ -1246,7 +1246,7 @@ Reload 會放棄您响 Notepad++ 改過嘅嘢，咁仲繼唔繼續呢？"/>
                     <Item id="3112" name="加資料夾"/>
                     <Item id="3113" name="加檔案..."/>
                     <Item id="3117" name="加資料夾入面啲檔案..."/>
-                    <Item id="3114" name="摌"/>
+                    <Item id="3114" name="剷"/>
                     <Item id="3118" name="移上"/>
                     <Item id="3119" name="移落"/>
                 </ProjectMenu>
@@ -1255,13 +1255,13 @@ Reload 會放棄您响 Notepad++ 改過嘅嘢，咁仲繼唔繼續呢？"/>
                     <Item id="3112" name="加資料夾"/>
                     <Item id="3113" name="加檔案..."/>
                     <Item id="3117" name="加資料夾入面啲檔案..."/>
-                    <Item id="3114" name="摌"/>
+                    <Item id="3114" name="剷"/>
                     <Item id="3118" name="移上"/>
                     <Item id="3119" name="移落"/>
                 </FolderMenu>
                 <FileMenu>
                     <Item id="3111" name="改名"/>
-                    <Item id="3115" name="摌"/>
+                    <Item id="3115" name="剷"/>
                     <Item id="3116" name="改檔案路徑"/>
                     <Item id="3118" name="移上"/>
                     <Item id="3119" name="移落"/>


### PR DESCRIPTION
我自己用開「鏟」，以前字幕佬都係用個「鏟」字

![de9155c358792e3801d6fb503a685f25c7625821_b](https://user-images.githubusercontent.com/602245/95661323-e9127900-0b60-11eb-9f90-f4d69323a839.jpg)



### [鏟](https://www.zdic.net/hant/%E9%8F%9F)

動
削平、挖除。
《文選·木華·海賦》：「於是乎禹也乃鏟臨崖之盂饇，決陂潢而相浚。」

除去、消滅。
唐·李紓〈故中書舍人吳郡朱府君神道碑〉：「國朝鏟邇代之弊，振中古之業。」
明·劉基〈祀方丘頌〉：「鋤秦鏟燕，掃貊滌戎。」


### [摌](https://www.zdic.net/hant/%E6%91%8C)
基本字義
　◎ 以手動物。

### 粵典:
### [鏟](https://words.hk/zidin/wan/?q=%E9%8F%9F)
Over 10 results

### [摌](https://words.hk/zidin/%E6%91%8C)
搵唔到「摌」
對唔住，字典入面搵唔到「摌」。

### Google site:hkgolden.com

鏟 site:hkgolden.com
約 41,700 項搜尋結果 (0.51 秒) 

摌 site:hkgolden.com
約 965 項搜尋結果 (0.28 秒) 