### PR TITLE
fix: change 摌 to 剷

### DIFF
--- a/hongKongCantonese.xml
+++ b/hongKongCantonese.xml
@@ -112,13 +112,13 @@
                     <Item id="42003" name="還原(&amp;U)"/>
                     <Item id="42004" name="重做(&amp;R)"/>
                     <Item id="42005" name="貼(&amp;P)"/>
-                    <Item id="42006" name="摌(&amp;D)"/>
+                    <Item id="42006" name="剷(&amp;D)"/>
                     <Item id="42007" name="揀晒全部(&amp;A)"/>
                     <Item id="42020" name="開始揀/揀完"/>
                     <Item id="42008" name="增加縮排"/>
                     <Item id="42009" name="減少縮排"/>
                     <Item id="42010" name="重複呢行"/>
-                    <Item id="42077" name="摌走連續又重複呢（幾）行"/>
+                    <Item id="42077" name="剷走連續又重複呢（幾）行"/>
                     <Item id="42012" name="分割呢行"/>
                     <Item id="42013" name="合併呢（幾）行"/>
                     <Item id="42014" name="移呢行上去"/>
@@ -157,7 +157,7 @@
                     <Item id="42042" name="剔走行前啲空格同𠹺 tab"/>
                     <Item id="42043" name="剔走呢行頭尾啲空格同𠹺 tab"/>
                     <Item id="42044" name="EOL -> 空格"/>
-                    <Item id="42045" name="摌走冇用嘅空格同𠹺 EOL"/>
+                    <Item id="42045" name="剷走冇用嘅空格同𠹺 EOL"/>
                     <Item id="42046" name="Tab -> 空格"/>
                     <Item id="42054" name="空格 -> tab（成份檔案）"/>
                     <Item id="42053" name="空格 -> tab（淨係行首）"/>
@@ -191,8 +191,8 @@
                     <Item id="42033" name="取消唯讀屬性"/>
                     <Item id="42035" name="轉做單行式註解"/>
                     <Item id="42036" name="取消單行式註解"/>
-                    <Item id="42055" name="摌走空行"/>
-                    <Item id="42056" name="摌走空行（只有空白字元嘅都照摌）"/>
+                    <Item id="42055" name="剷走空行"/>
+                    <Item id="42056" name="剷走空行（只有空白字元嘅都照剷）"/>
                     <Item id="42057" name="响上面加一行"/>
                     <Item id="42058" name="响下面加一行"/>
 
@@ -208,8 +208,8 @@
                     <Item id="43018" name="剪低書籤嗰幾行"/>
                     <Item id="43019" name="抄低書籤嗰幾行"/>
                     <Item id="43020" name="貼去兼取代書籤嗰幾行"/>
-                    <Item id="43021" name="摌走書籤嗰幾行"/>
-                    <Item id="43051" name="摌走冇書籤標記嗰幾行"/>
+                    <Item id="43021" name="剷走書籤嗰幾行"/>
+                    <Item id="43051" name="剷走冇書籤標記嗰幾行"/>
                     <Item id="43050" name="反向標記書籤"/>
                     <Item id="43052" name="以字元編號搵字元..."/>
                     <Item id="43053" name="揀選括號之間所有嘅字元"/>
@@ -385,13 +385,13 @@
 
                     <!-- menu: File (cont'd) -->
                     <Item id="42040" name="打開所有最近用過嘅檔案"/>
-                    <Item id="42041" name="摌晒最近用過嘅檔案記錄"/>
+                    <Item id="42041" name="剷晒最近用過嘅檔案記錄"/>
 
                     <!-- menu: Macro (cont'd) -->
-                    <Item id="48016" name="修改快捷鍵或者摌走 Macro..."/>
+                    <Item id="48016" name="修改快捷鍵或者剷走 Macro..."/>
 
                     <!-- menu: Run (cont'd) -->
-                    <Item id="48017" name="修改快捷鍵或者摌走執行指令..."/>
+                    <Item id="48017" name="修改快捷鍵或者剷走執行指令..."/>
 
                 </Commands>
             </Main>
@@ -523,7 +523,7 @@
                 <Item id="5501" name="搵："/>
                 <Item id="5503" name="安裝"/>
                 <Item id="5504" name="更新"/>
-                <Item id="5505" name="摌走"/>
+                <Item id="5505" name="剷走"/>
                 <Item id="5508" name="下一個"/>
                 <Item id="2"    name="閂"/>
             </PluginsAdminDlg>
@@ -561,7 +561,7 @@
 
             <ShortcutMapper title="管理快捷鍵">
                 <Item id="2602" name="修改"/>
-                <Item id="2603" name="摌走"/>
+                <Item id="2603" name="剷走"/>
                 <Item id="2606" name="清除"/>
                 <Item id="2607" name="過濾："/>
                 <Item id="1" name="閂"/>
@@ -583,9 +583,9 @@
                 <Item id="2" name="取消"/>
                 <Item id="5006" name="名稱"/>
                 <Item id="5008" name="增加"/>
-                <Item id="5009" name="摌走"/>
+                <Item id="5009" name="剷走"/>
                 <Item id="5010" name="套用"/>
-                <Item id="5007" name="咁會摌走快捷鍵"/>
+                <Item id="5007" name="咁會剷走快捷鍵"/>
                 <Item id="5012" name="有衝突啊喂！"/>
             </ShortcutMapperSubDialg>
 
@@ -593,7 +593,7 @@
                 <Item id="20001" name="靠邊"/>
                 <Item id="20002" name="改名"/>
                 <Item id="20003" name="開新..."/>
-                <Item id="20004" name="摌除"/>
+                <Item id="20004" name="剷除"/>
                 <Item id="20005" name="Save 做新..."/>
                 <Item id="20007" name="自訂程式語言："/>
                 <Item id="20009" name="副檔名："/>
@@ -1099,7 +1099,7 @@
             <DocReloadWarning title="响磁碟重新 load 過" message="留意番！改過嘅嘢會冇晒，係咪真係要再 load 過呢個檔案？"/> <!-- #todo reproduce -->
             <FileLockedWarning title="儲存失敗" message="麻煩你檢查吓，係咪有其它應用程式開咗呢個檔案。"/> <!-- #todo reproduce -->
             <FileAlreadyOpenedInNpp title="" message="已經响 Notepad++ 度開咗呢個檔案。"/> <!-- #todo reproduce -->
-            <DeleteFileFailed title="掉去垃圾桶" message="摌唔走個檔案。"/> <!-- #todo reproduce -->
+            <DeleteFileFailed title="掉去垃圾桶" message="剷唔走個檔案。"/> <!-- #todo reproduce -->
 
             <NbFileToOpenImportantWarning title="太多檔案" message="成 $INT_REPLACE$ 個檔案咁多，
 係咪真係要開晒先？"/> <!-- #todo reproduce -->
@@ -1117,8 +1117,8 @@
 仲使唔使 keep 著呢個檔案呢？"/> <!-- #todo reproduce -->
             <DoDeleteOrNot title="刪檔案" message="咁做會掉去垃圾桶仲會閂咗呢個檔案
 「$STR_REPLACE$」，
-係咪真係要摌先？"/> <!-- #todo reproduce -->
-            <NoBackupDoSaveFile title="Save" message="檔案嘅備份已經畀另一個程式摌走咗。
+係咪真係要剷先？"/> <!-- #todo reproduce -->
+            <NoBackupDoSaveFile title="Save" message="檔案嘅備份已經畀另一個程式剷走咗。
 如果唔想遺失數據就 save 低佢啦。
 您想唔想 save「$STR_REPLACE$」呢？"/> <!-- #todo reproduce -->
             <DoReloadOrNot title="Reload" message="「$STR_REPLACE$」
@@ -1147,7 +1147,7 @@ Reload 會放棄你响 Notepad++ 改過嘅嘢，咁仲繼唔繼續呢？"/> <!--
 使唔使回復個檔案？"/> <!-- #todo reproduce -->
             <LoadLangsFailedFinal title="設定" message="Load 唔到「langs.xml」。"/> <!-- #todo reproduce -->
             <FolderAsWorspaceSubfolderExists title="資料夾工作區問題" message="您要加入嘅資料夾「$STR_REPLACE$」，已經以子資料夾嘅形式出現响工作區裏面。
-如果您仍然想咁做，唯有响工作區摌走包含佢嘅資料夾，先至可以加番上去。"/> <!-- #todo reproduce -->
+如果您仍然想咁做，唯有响工作區剷走包含佢嘅資料夾，先至可以加番上去。"/> <!-- #todo reproduce -->
 
             <ProjectPanelChanged title="$STR_REPLACE$" message="Project 面板被修改過。使唔使 save？"/> <!-- #todo reproduce -->
             <ProjectPanelChangedSaveError title="$STR_REPLACE$" message="Project 面板 save 唔到。"/> <!-- #todo reproduce -->
@@ -1155,16 +1155,16 @@ Reload 會放棄你响 Notepad++ 改過嘅嘢，咁仲繼唔繼續呢？"/> <!--
             <ProjectPanelNewDoSaveDirtyWsOrNot title="新 Project 面板" message="您用𡁵呢個 Project 面板改過嘢，使唔使 save 咗佢先呢？"/> <!-- #todo reproduce -->
             <ProjectPanelOpenFailed title="打開 Project 面板" message="打唔開個 Project 面板。
 似乎係個工作區檔案無效或者損毀咗。"/> <!-- #todo reproduce -->
-            <ProjectPanelRemoveFolderFromProject title="响 project 度摌走資料夾" message="咁樣會摌走收𠹺啲子資料夾。
-係咪真係要响 project 度摌走資料夾？"/> <!-- #todo reproduce -->
-            <ProjectPanelRemoveFileFromProject title="响 project 度摌走檔案" message="係咪真係要响 project 度摌走呢個檔案？"/> <!-- #todo reproduce -->
+            <ProjectPanelRemoveFolderFromProject title="响 project 度剷走資料夾" message="咁樣會剷走收𠹺啲子資料夾。
+係咪真係要响 project 度剷走資料夾？"/> <!-- #todo reproduce -->
+            <ProjectPanelRemoveFileFromProject title="响 project 度剷走檔案" message="係咪真係要响 project 度剷走呢個檔案？"/> <!-- #todo reproduce -->
             <ProjectPanelReloadError title="Reload 工作區" message="搵唔到要 reload 嘅檔案。"/> <!-- #todo reproduce -->
             <ProjectPanelReloadDirty title="Reload 工作區" message="呢個工作區已經改過嘢。Reload 捨棄啲改動。
 仲繼唔繼續？"/> <!-- #todo reproduce -->
             <UDLNewNameError title="自訂程式語言錯誤" message="呢個名已經畀另一個程式語言用咗。
 麻煩改過個名。"/> <!-- #todo reproduce -->
-            <UDLRemoveCurrentLang title="摌除程式語言" message="係咪真係要咁做？"/> <!-- #todo reproduce -->
-            <SCMapperDoDeleteOrNot title="摌除快捷鍵" message="係咪真係要咁做"/> <!-- #todo reproduce -->
+            <UDLRemoveCurrentLang title="剷除程式語言" message="係咪真係要咁做？"/> <!-- #todo reproduce -->
+            <SCMapperDoDeleteOrNot title="剷除快捷鍵" message="係咪真係要咁做"/> <!-- #todo reproduce -->
             <FindCharRangeValueError title="輸入值範圍錯誤" message="您輸入嘅數值應該要介乎 0 到 255 之間先至啱。"/> <!-- #todo reproduce -->
             <OpenInAdminMode title="Save 唔到" message="Save 唔到，可能係因為個檔案响保護狀態。
 想唔想用系統管理員權限重新打開 Notepad++？"/> <!-- #todo reproduce -->
@@ -1211,8 +1211,8 @@ Reload 會放棄你响 Notepad++ 改過嘅嘢，咁仲繼唔繼續呢？"/> <!--
             <PanelTitle name="資料夾工作區"/>
             <SelectFolderFromBrowserString name="揀個資料夾嚟加入去資料夾工作區"/>
             <Menus>
-                <Item id="3511" name="摌走"/>
-                <Item id="3512" name="摌晒去"/>
+                <Item id="3511" name="剷走"/>
+                <Item id="3512" name="剷晒去"/>
                 <Item id="3513" name="加料"/>
                 <Item id="3514" name="响系統預設程式打開"/>
                 <Item id="3515" name="打開"/>
@@ -1247,7 +1247,7 @@ Reload 會放棄你响 Notepad++ 改過嘅嘢，咁仲繼唔繼續呢？"/> <!--
                     <Item id="3112" name="加資料夾"/>
                     <Item id="3113" name="加檔案..."/>
                     <Item id="3117" name="加資料夾入面啲檔案..."/>
-                    <Item id="3114" name="摌"/>
+                    <Item id="3114" name="剷"/>
                     <Item id="3118" name="移上"/>
                     <Item id="3119" name="移落"/>
                 </ProjectMenu>
@@ -1256,13 +1256,13 @@ Reload 會放棄你响 Notepad++ 改過嘅嘢，咁仲繼唔繼續呢？"/> <!--
                     <Item id="3112" name="加資料夾"/>
                     <Item id="3113" name="加檔案..."/>
                     <Item id="3117" name="加資料夾入面啲檔案..."/>
-                    <Item id="3114" name="摌"/>
+                    <Item id="3114" name="剷"/>
                     <Item id="3118" name="移上"/>
                     <Item id="3119" name="移落"/>
                 </FolderMenu>
                 <FileMenu>
                     <Item id="3111" name="改名"/>
-                    <Item id="3115" name="摌"/>
+                    <Item id="3115" name="剷"/>
                     <Item id="3116" name="改檔案路徑"/>
                     <Item id="3118" name="移上"/>
                     <Item id="3119" name="移落"/>


### PR DESCRIPTION
「剷走」、「剷除」 is more common and closer in meaning to most of those deletions.

---
Reference:
* https://chardb.iis.sinica.edu.tw/meancompare/93DF/5277
* https://shyyp.net/hant/w/%E6%91%8C